### PR TITLE
🎨Design: 검색 기록 페이지 피드백 반영 #41

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { SearchMain } from './pages/search/SearchMainPage';
 import { SearchByCategory } from './pages/search/SearchByCategoryPage';
 import { SearchTrendingGroup } from 'pages/search/SearchTrendingGroupPage';
 import { SearchTrendingFolder } from 'pages/search/SearchTrendingFolderPage';
+import { SearchHistory } from 'pages/search/SearchHistoryPage';
 import { ProfilePage } from './pages/profile/ProfilePage';
 import { ProfileUpdatePage } from 'pages/profile/ProfileUpdatePage';
 import { ProfileGroupDetailPage } from './pages/profile/ProfileGroupDetailPage';
@@ -28,7 +29,8 @@ export function App(): JSX.Element {
         <Route path="/profilePage" element={<ProfilePage />} />
         <Route path="/searchmain" element={<SearchMain />} />
         <Route path="/trendingfolder" element={<SearchTrendingFolder />} />
-        <Route path="trendinggroup" element={<SearchTrendingGroup />} />
+        <Route path="/trendinggroup" element={<SearchTrendingGroup />} />
+        <Route path="/searchhistory" element={<SearchHistory />} />
         <Route path="/searchbycategory" element={<SearchByCategory />} />
         <Route path="/profileUpdatePage" element={<ProfileUpdatePage />} />
         <Route

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -1,15 +1,31 @@
 import styled from 'styled-components';
-
+import { useNavigate, useLocation } from 'react-router-dom';
 import { BackButton } from 'components/common/BackButton';
+
 import search from '../../assets/icon/icon-search.svg';
 
-interface SearchBarProps {
-  onInputClick: () => void;
-}
+export const SearchBar: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
 
-export const SearchBar: React.FC<SearchBarProps> = ({ onInputClick }) => {
+  const handleInputClick = (): void => {
+    console.log('Input has been clicked!');
+    if (location.pathname !== '/searchhistory') {
+      navigate('/searchhistory');
+    }
+  };
+
+  const handleInputFocus = (): void => {
+    console.log('Input has been Focused!');
+    if (location.pathname !== '/searchhistory') {
+      navigate('/searchhistory');
+    }
+  };
+
   const handleSearchButtonClick = (): void => {
-    console.log('SearchButton has been clicked!');
+    if (location.pathname === '/searchhistory') {
+      console.log('검색 시작!');
+    }
   };
 
   return (
@@ -19,7 +35,8 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onInputClick }) => {
         <SearchInput
           type="text"
           placeholder="검색어를 입력하세요"
-          onClick={onInputClick}
+          onClick={handleInputClick}
+          onFocus={handleInputFocus}
         />
         <SearchButton onClick={handleSearchButtonClick} />
       </SearchArea>

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -4,27 +4,39 @@ import { BackButton } from 'components/common/BackButton';
 
 import search from '../../assets/icon/icon-search.svg';
 
-export const SearchBar: React.FC = () => {
+export interface SearchBarProps {
+  onSearchButtonClick?: () => void;
+}
+
+export const SearchBar: React.FC<SearchBarProps> = ({
+  onSearchButtonClick,
+}) => {
   const navigate = useNavigate();
   const location = useLocation();
 
   const handleInputClick = (): void => {
     console.log('Input has been clicked!');
-    if (location.pathname !== '/searchhistory') {
+    if (
+      location.pathname !== '/searchhistory' &&
+      !location.pathname.startsWith('/profiledetailPage/')
+    ) {
       navigate('/searchhistory');
     }
   };
 
   const handleInputFocus = (): void => {
     console.log('Input has been Focused!');
-    if (location.pathname !== '/searchhistory') {
+    if (
+      location.pathname !== '/searchhistory' &&
+      !location.pathname.startsWith('/profiledetailPage/')
+    ) {
       navigate('/searchhistory');
     }
   };
 
   const handleSearchButtonClick = (): void => {
-    if (location.pathname === '/searchhistory') {
-      console.log('검색 시작!');
+    if (onSearchButtonClick) {
+      onSearchButtonClick();
     }
   };
 

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { BackButton } from 'components/common/BackButton';
 
 import search from '../../assets/icon/icon-search.svg';
+import { useEffect, useState } from 'react';
 
 export interface SearchBarProps {
   onSearchButtonClick?: () => void;
@@ -13,12 +14,26 @@ export const SearchBar: React.FC<SearchBarProps> = ({
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const currentPath = location.pathname;
+  const [placeholderText, SetPlaceHolderText] = useState('');
+
+  useEffect(() => {
+    if (currentPath === '/profiledetailPage/1') {
+      SetPlaceHolderText('내가 참여한 그룹은?');
+    } else if (currentPath === '/profiledetailPage/2') {
+      SetPlaceHolderText('내가 팔로우한 그룹은?');
+    } else if (currentPath === '/chatting') {
+      SetPlaceHolderText('내가 마지막으로 이야기를 나눈 친구는?');
+    } else if (currentPath === '/searchhistory') {
+      SetPlaceHolderText('나는 뭘 검색했을까?👀');
+    } else SetPlaceHolderText('요즘 소윗에서 가장 핫한 검색어는?');
+  }, [currentPath]);
 
   const handleInputClick = (): void => {
     if (
-      location.pathname !== '/searchhistory' &&
-      !location.pathname.startsWith('/profiledetailPage/') &&
-      !location.pathname.startsWith('/chatting')
+      currentPath !== '/searchhistory' &&
+      !currentPath.startsWith('/profiledetailPage/') &&
+      !currentPath.startsWith('/chatting')
     ) {
       navigate('/searchhistory');
     }
@@ -26,9 +41,9 @@ export const SearchBar: React.FC<SearchBarProps> = ({
 
   const handleInputFocus = (): void => {
     if (
-      location.pathname !== '/searchhistory' &&
-      !location.pathname.startsWith('/profiledetailPage/') &&
-      !location.pathname.startsWith('/chatting')
+      currentPath !== '/searchhistory' &&
+      !currentPath.startsWith('/profiledetailPage/') &&
+      !currentPath.startsWith('/chatting')
     ) {
       navigate('/searchhistory');
     }
@@ -46,7 +61,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
       <SearchArea>
         <SearchInput
           type="text"
-          placeholder="검색어를 입력하세요"
+          placeholder={placeholderText}
           onClick={handleInputClick}
           onFocus={handleInputFocus}
         />

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -15,20 +15,20 @@ export const SearchBar: React.FC<SearchBarProps> = ({
   const location = useLocation();
 
   const handleInputClick = (): void => {
-    console.log('Input has been clicked!');
     if (
       location.pathname !== '/searchhistory' &&
-      !location.pathname.startsWith('/profiledetailPage/')
+      !location.pathname.startsWith('/profiledetailPage/') &&
+      !location.pathname.startsWith('/chatting')
     ) {
       navigate('/searchhistory');
     }
   };
 
   const handleInputFocus = (): void => {
-    console.log('Input has been Focused!');
     if (
       location.pathname !== '/searchhistory' &&
-      !location.pathname.startsWith('/profiledetailPage/')
+      !location.pathname.startsWith('/profiledetailPage/') &&
+      !location.pathname.startsWith('/chatting')
     ) {
       navigate('/searchhistory');
     }

--- a/src/pages/profile/ProfileGroupDetailPage.tsx
+++ b/src/pages/profile/ProfileGroupDetailPage.tsx
@@ -1,35 +1,24 @@
-import { styled } from "styled-components";
-import { useState } from "react";
-import { useParams } from "react-router-dom";
+import { styled } from 'styled-components';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 
-import { GroupUI } from "components/common/GroupUI";
-import { SearchBar } from "../../components/search/SearchBar";
-
+import { GroupUI } from 'components/common/GroupUI';
+import { SearchBar } from '../../components/search/SearchBar';
 
 export const ProfileGroupDetailPage = () => {
   const { currentStep } = useParams();
   const [detailPage, setDetailPage] = useState<number>(
-    parseInt(currentStep || "1")
+    parseInt(currentStep || '1')
   );
 
   const openTabMenu = (e) => {
     setDetailPage(e);
   };
 
-  // const [isInputClicked, setInputClicked] = useState(false);
-
-  const handleInputClick = () => {
-    // setInputClicked(true);
-  };
-
-  const handleCancel = () => {
-    // setInputClicked(false);
-  };
-
   return (
     <ProfileGroupDetailPageWrap>
-      <div style={{marginTop: "20px", marginBottom: "20px"}}>
-        <SearchBar onInputClick={handleInputClick}/>
+      <div style={{ marginTop: '20px', marginBottom: '20px' }}>
+        <SearchBar />
       </div>
       {detailPage === 1 ? (
         <>

--- a/src/pages/profile/ProfileGroupDetailPage.tsx
+++ b/src/pages/profile/ProfileGroupDetailPage.tsx
@@ -15,10 +15,14 @@ export const ProfileGroupDetailPage = () => {
     setDetailPage(e);
   };
 
+  const callSearchAPI = () => {
+    console.log('검색 API 호출');
+  };
+
   return (
     <ProfileGroupDetailPageWrap>
       <div style={{ marginTop: '20px', marginBottom: '20px' }}>
-        <SearchBar />
+        <SearchBar onSearchButtonClick={callSearchAPI} />
       </div>
       {detailPage === 1 ? (
         <>

--- a/src/pages/search/SearchByCategoryPage.tsx
+++ b/src/pages/search/SearchByCategoryPage.tsx
@@ -1,7 +1,6 @@
 import { useState, FC } from 'react';
 import { styled } from 'styled-components';
 import { SearchBar } from '../../components/search/SearchBar';
-import { SearchHistory } from 'components/search/SearchHistory';
 import { StepBar } from '../../components/common/StepBar';
 import { PostList } from '../../components/search/SearchPostList';
 import { SearchFolderList } from 'components/search/SearchFolderList';
@@ -59,26 +58,22 @@ export const SearchByCategory: FC = () => {
   return (
     <>
       <h1 className="a11y-hidden">검색 페이지/게시글</h1>
-      <SearchBar onInputClick={handleInputClick} />
-      {isInputClicked ? (
-        <SearchHistory onCancel={handleCancel} />
-      ) : (
-        <Container>
-          <CategorySwitcher>
-            {CATEGORIES.map((category) => (
-              <button
-                key={category.id}
-                className={category.className}
-                onClick={() => handleButtonClick(category.id)}
-              >
-                {category.name}
-              </button>
-            ))}
-          </CategorySwitcher>
-          <StepBar currentStep={currentStep} howManyTabs={5} />
-          {renderComponentByCategory()}
-        </Container>
-      )}
+      <Container>
+        <SearchBar />
+        <CategorySwitcher>
+          {CATEGORIES.map((category) => (
+            <button
+              key={category.id}
+              className={category.className}
+              onClick={() => handleButtonClick(category.id)}
+            >
+              {category.name}
+            </button>
+          ))}
+        </CategorySwitcher>
+        <StepBar currentStep={currentStep} howManyTabs={5} />
+        {renderComponentByCategory()}
+      </Container>
     </>
   );
 };
@@ -87,15 +82,13 @@ const Container = styled.div`
   width: 100%;
   background-color: #ffffff;
   margin: 0 auto;
-
-  margin-top: 60px;
 `;
 
 const CategorySwitcher = styled.div`
   display: flex;
   justify-content: space-evenly;
   width: 88%;
-  margin: 0 auto 5px auto;
+  margin: 60px auto 5px auto;
 
   button {
     display: block;

--- a/src/pages/search/SearchHistoryPage.tsx
+++ b/src/pages/search/SearchHistoryPage.tsx
@@ -57,10 +57,14 @@ export const SearchHistory: React.FC<SearchHistoryProps> = () => {
     setSearchHistoryData(updatedData);
   };
 
+  const callSearchAPI = (): void => {
+    console.log('검색 API 호출');
+  };
+
   return (
     <Container>
       <h1 className="a11y-hidden">검색 기록 페이지</h1>
-      <SearchBar />
+      <SearchBar onSearchButtonClick={callSearchAPI} />
       {userSearchHistory && (
         <YesSearchHistory>
           <SearchStatus>

--- a/src/pages/search/SearchHistoryPage.tsx
+++ b/src/pages/search/SearchHistoryPage.tsx
@@ -1,15 +1,14 @@
+import styled from 'styled-components';
 import { useState, useEffect } from 'react';
-import { styled } from 'styled-components';
 import {
   HistoryItem,
   HistoryItemProps,
-} from '../../components/search/SearchHistoryItem';
+} from 'components/search/SearchHistoryItem';
+import { SearchBar } from 'components/search/SearchBar';
 
 import soWithLogo from '../../assets/icon/icon-sowith-heart.svg';
 
-interface SearchHistoryProps {
-  onCancel: () => void;
-}
+interface SearchHistoryProps {}
 
 const sampleData: HistoryItemProps[] = [
   {
@@ -42,7 +41,7 @@ const sampleData: HistoryItemProps[] = [
 
 export default sampleData;
 
-export const SearchHistory: React.FC<SearchHistoryProps> = ({ onCancel }) => {
+export const SearchHistory: React.FC<SearchHistoryProps> = () => {
   const [searchHistoryData, setSearchHistoryData] = useState(sampleData);
   const [userSearchHistory, setUserSearchHistory] = useState<boolean>(true);
 
@@ -59,42 +58,39 @@ export const SearchHistory: React.FC<SearchHistoryProps> = ({ onCancel }) => {
   };
 
   return (
-    <>
-      <h1 className="a11y-hidden">검색 페이지</h1>
-      <Container>
-        {userSearchHistory && (
-          <YesSearchHistory>
-            <SearchStatus>
-              <p>최근 검색 기록</p>
-              <button onClick={onCancel}>취소</button>
-            </SearchStatus>
+    <Container>
+      <h1 className="a11y-hidden">검색 기록 페이지</h1>
+      <SearchBar />
+      {userSearchHistory && (
+        <YesSearchHistory>
+          <SearchStatus>
+            <p>최근 검색 기록</p>
+          </SearchStatus>
 
-            <SearchHistoryList>
-              {searchHistoryData.map((data, index) => (
-                <HistoryItem
-                  key={index}
-                  {...(data as HistoryItemProps)}
-                  onDelete={() => handleDeleteHistoryItem(index)}
-                />
-              ))}
-            </SearchHistoryList>
-          </YesSearchHistory>
-        )}
+          <SearchHistoryList>
+            {searchHistoryData.map((data, index) => (
+              <HistoryItem
+                key={index}
+                {...(data as HistoryItemProps)}
+                onDelete={() => handleDeleteHistoryItem(index)}
+              />
+            ))}
+          </SearchHistoryList>
+        </YesSearchHistory>
+      )}
 
-        {!userSearchHistory && (
-          <NoSearchHistory>
-            <SearchStatus>
-              <p>최근 검색 기록</p>
-              <button onClick={onCancel}>취소</button>
-            </SearchStatus>
-            <NoSearchHistoryIcon>
-              <img src={soWithLogo} alt="SoWith Logo" />
-              <span>검색 기록이 없어요</span>
-            </NoSearchHistoryIcon>
-          </NoSearchHistory>
-        )}
-      </Container>
-    </>
+      {!userSearchHistory && (
+        <NoSearchHistory>
+          <SearchStatus>
+            <p>최근 검색 기록</p>
+          </SearchStatus>
+          <NoSearchHistoryIcon>
+            <img src={soWithLogo} alt="SoWith Logo" />
+            <span>검색 기록이 없어요</span>
+          </NoSearchHistoryIcon>
+        </NoSearchHistory>
+      )}
+    </Container>
   );
 };
 
@@ -102,9 +98,20 @@ const Container = styled.div`
   width: 100%;
   background-color: #ffffff;
   margin: 0 auto;
+  padding-bottom: 10px;
+
+  h2 {
+    margin: 0;
+  }
+
+  > section {
+    padding-top: 18px;
+  }
 `;
 
 const YesSearchHistory = styled.div`
+  margin: 30px auto 30px auto;
+
   > p {
     width: 88%;
     margin: 0 auto;
@@ -124,7 +131,14 @@ const SearchStatus = styled.div`
 
 const SearchHistoryList = styled.section``;
 
-const NoSearchHistory = styled.div``;
+const NoSearchHistory = styled.div`
+  margin: 30px auto 30px auto;
+
+  > p {
+    width: 88%;
+    margin: 0 auto;
+  }
+`;
 
 const NoSearchHistoryIcon = styled.div`
   display: flex;

--- a/src/pages/search/SearchMainPage.tsx
+++ b/src/pages/search/SearchMainPage.tsx
@@ -2,7 +2,6 @@ import { FC, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { SearchBar } from '../../components/search/SearchBar';
-import { SearchHistory } from 'components/search/SearchHistory';
 import { GroupUI } from '../../components/common/GroupUI';
 import { SearchTrendingFolderList } from 'components/search/SearchTrendingFolderList';
 import { SearchTrendingTagList } from 'components/search/SearchTrendingTagList';
@@ -14,53 +13,39 @@ interface SectionTitleProps {
 }
 
 export const SearchMain: FC = () => {
-  const [isInputClicked, setInputClicked] = useState(false);
-
-  const handleInputClick = () => {
-    setInputClicked(true);
-  };
-
-  const handleCancel = () => {
-    setInputClicked(false);
-  };
-
   const trendingGroups = [1, 2, 3, 4, 5, 6];
 
   return (
     <>
       <h1 className="a11y-hidden">검색 메인 페이지</h1>
       <MainTopNav>
-        <SearchBar onInputClick={handleInputClick} />
+        <SearchBar />
         <SearchTrendingTagList />
       </MainTopNav>
-      {isInputClicked ? (
-        <SearchHistory onCancel={handleCancel} />
-      ) : (
-        <Container>
-          <TrendingFolder>
-            <SectionTitle index={1}>
-              <h2>인기 폴더</h2>
-              <Link to="/trendingfolder">
-                <img src={arrowNext} alt="인기 폴더 더보기" />
-              </Link>
-            </SectionTitle>
-            <SearchTrendingFolderList />
-          </TrendingFolder>
-          <TrendingGroup>
-            <SectionTitle index={2}>
-              <h2>인기 그룹</h2>
-              <Link to="/trendinggroup">
-                <img src={arrowNext} alt="인기 그룹 더보기" />
-              </Link>
-            </SectionTitle>
-            <TrendingGroupList>
-              {trendingGroups.map((_, idx) => (
-                <GroupUI key={idx} />
-              ))}
-            </TrendingGroupList>
-          </TrendingGroup>
-        </Container>
-      )}
+      <Container>
+        <TrendingFolder>
+          <SectionTitle index={1}>
+            <h2>인기 폴더</h2>
+            <Link to="/trendingfolder">
+              <img src={arrowNext} alt="인기 폴더 더보기" />
+            </Link>
+          </SectionTitle>
+          <SearchTrendingFolderList />
+        </TrendingFolder>
+        <TrendingGroup>
+          <SectionTitle index={2}>
+            <h2>인기 그룹</h2>
+            <Link to="/trendinggroup">
+              <img src={arrowNext} alt="인기 그룹 더보기" />
+            </Link>
+          </SectionTitle>
+          <TrendingGroupList>
+            {trendingGroups.map((_, idx) => (
+              <GroupUI key={idx} />
+            ))}
+          </TrendingGroupList>
+        </TrendingGroup>
+      </Container>
     </>
   );
 };


### PR DESCRIPTION
> 이슈 번호: #41 

## 전달 사항
23.10.06에 진행된 회의에서 `SearchBar` 컴포넌트 관련 피드백을 반영한 PR입니다.
## 주요 변경 사항
```jsx
const handleInputClick = (): void => {
    if (
      location.pathname !== '/searchhistory' &&
      !location.pathname.startsWith('/profiledetailPage/') &&
      !location.pathname.startsWith('/chatting')
    ) {
      navigate('/searchhistory');
    }
  };

  const handleInputFocus = (): void => {
    if (
      location.pathname !== '/searchhistory' &&
      !location.pathname.startsWith('/profiledetailPage/') &&
      !location.pathname.startsWith('/chatting')
    ) {
      navigate('/searchhistory');
    }
  };
```
이제 채팅 페이지에서 `SearchInput`을 클릭하거나 포커스 해도 검색 기록 페이지로 이동하지 않습니다.

```jsx
const navigate = useNavigate();
  const location = useLocation();
  const currentPath = location.pathname;
  const [placeholderText, SetPlaceHolderText] = useState('');

  useEffect(() => {
    if (currentPath === '/profiledetailPage/1') {
      SetPlaceHolderText('내가 참여한 그룹은?');
    } else if (currentPath === '/profiledetailPage/2') {
      SetPlaceHolderText('내가 팔로우한 그룹은?');
    } else if (currentPath === '/chatting') {
      SetPlaceHolderText('내가 마지막으로 이야기를 나눈 친구는?');
    } else if (currentPath === '/searchhistory') {
      SetPlaceHolderText('나는 뭘 검색했을까?👀');
    } else SetPlaceHolderText('요즘 소윗에서 가장 핫한 검색어는?');
  }, [currentPath]);

// SearchInput 컴포넌트
<SearchInput type="text" placeholder={placeholderText} onClick={handleInputClick} onFocus={handleInputFocus} />
```
`SearchBar`가 렌더링 된 페이지에 따라서 placeholder의 텍스트를 조건부로 적용하도록 변경했습니다.
useEffect 부분의 중복을 줄일 수 있는 방법이 있을 것 같은데, 추후 리팩토링 과정에서 수정하도록 하겠습니다.

## 추가 작업
추가적인 피드백이 있을 경우 작업할 예정입니다.