### PR TITLE
🛠Feat: 검색 기능 구현 #22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.0.tgz",
-      "integrity": "sha512-+RNNcQvw2V1bmnBTPAtOLfW/9mhH2vC67+rUSi5T8EtEWt6lEnGNY2GuhZ1/YwbgikT1TkhvidCDmN5Q5YCo/w=="
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw=="
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -152,11 +152,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
-      "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dependencies": {
-        "@babel/highlight": "^7.22.10",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -242,11 +242,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
-      "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
+      "integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
       "dependencies": {
-        "@babel/types": "^7.22.10",
+        "@babel/types": "^7.23.5",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -370,20 +370,20 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -525,17 +525,17 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -575,11 +575,11 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
-      "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
@@ -588,9 +588,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
-      "integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
+      "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -2324,31 +2324,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-      "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/parser": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
-      "integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
+      "integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.10",
-        "@babel/generator": "^7.22.10",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.10",
-        "@babel/types": "^7.22.10",
+        "@babel/parser": "^7.23.5",
+        "@babel/types": "^7.23.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -2357,12 +2357,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.10.tgz",
-      "integrity": "sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
+      "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -17037,9 +17037,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -17925,9 +17925,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -17943,7 +17943,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -19516,9 +19516,9 @@
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.28.0.tgz",
-      "integrity": "sha512-E3C3X1skWBdBzwpOUbmXG8SgH6BtsluSMe+s6rRcujNKG1DGi8uIfhdhszkgDpAsMoE55hwqRUzeXCmETDBpTg==",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.28.5.tgz",
+      "integrity": "sha512-cq/o30z9W2Wb4rzBefjv5fBalHU0rJGZCHAkf/RHSBWSSYwh8PlQTqqOJmgIIbBtpj27T6FIPXeomIjZtCNVqA==",
       "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",

--- a/src/components/search/SearchHistoryItem.tsx
+++ b/src/components/search/SearchHistoryItem.tsx
@@ -21,8 +21,8 @@ type HistoryCategory = 'text' | 'tag' | 'user' | 'folder' | 'group';
 export interface HistoryItemProps {
 	historyCategory: HistoryCategory;
 	title: string;
-	relatedPosts?: number;
-	followers?: number;
+	relatedPost?: number;
+	followerCount?: number;
 	likes?: number;
 	folderTag?: string;
 	groupTag?: string;
@@ -33,8 +33,8 @@ export interface HistoryItemProps {
 export const HistoryItem: React.FC<HistoryItemProps> = ({
 	historyCategory,
 	title,
-	relatedPosts,
-	followers,
+	relatedPost,
+	followerCount,
 	likes,
 	folderTag,
 	groupTag,
@@ -65,7 +65,7 @@ export const HistoryItem: React.FC<HistoryItemProps> = ({
 					{historyCategory === 'text' && <></>}
 
 					{historyCategory === 'tag' && (
-						<span className='description-tag'>게시물 {relatedPosts}+개</span>
+						<span className='description-tag'>게시물 {relatedPost}+개</span>
 					)}
 
 					{historyCategory === 'user' && (
@@ -76,7 +76,7 @@ export const HistoryItem: React.FC<HistoryItemProps> = ({
 							{isFollowing ? (
 								<span className='user-state'>팔로잉</span>
 							) : (
-								<span className='user-state'>팔로워 {followers}명</span>
+								<span className='user-state'>팔로워 {followerCount}명</span>
 							)}
 						</>
 					)}

--- a/src/hooks/useDeleteSearchHistory.ts
+++ b/src/hooks/useDeleteSearchHistory.ts
@@ -1,0 +1,26 @@
+import { useFirestoreDelete } from './useFirestoreDelete';
+
+export const useDeleteSearchHistory = () => {
+	const { DeleteSearchHistoryEntry } = useFirestoreDelete('users');
+
+	const deleteSearchHistory = async (userId, historyIndex) => {
+		try {
+			// userId와 historyIndex가 유효한지 확인
+			if (userId && historyIndex >= 0) {
+				console.log(userId, historyIndex);
+				// 해당 사용자의 문서 ID
+				const documentId = userId;
+
+				// DeleteSearchHistoryEntry 함수를 사용하여 검색 기록 삭제
+				await DeleteSearchHistoryEntry(documentId, historyIndex);
+				console.log('검색 기록이 성공적으로 삭제되었습니다.');
+			} else {
+				console.error('유효하지 않은 userId 또는 historyIndex입니다.');
+			}
+		} catch (error) {
+			console.error('검색 기록 삭제 중 오류 발생:', error);
+		}
+	};
+
+	return { deleteSearchHistory };
+};

--- a/src/hooks/useFirestoreCreate.tsx
+++ b/src/hooks/useFirestoreCreate.tsx
@@ -1,25 +1,37 @@
 import { appFireStore, timestamp } from '../firebase/config';
-import { collection, addDoc } from 'firebase/firestore';
+import { collection, addDoc, doc, setDoc } from 'firebase/firestore';
 
 export const useFirestoreCreate = (collectionName) => {
+	const token = sessionStorage.getItem('token');
+	const uid = token !== null ? JSON.parse(token).uid : null;
 
-  const token = sessionStorage.getItem('token');
-  const uid = token !== null ? JSON.parse(token).uid : null;
+	const CreateDocument = async (data) => {
+		try {
+			if (uid !== null) {
+				const createdAt = timestamp.fromDate(new Date());
+				data.userId = uid;
+				const docRef = await addDoc(collection(appFireStore, collectionName), {
+					...data,
+					createdAt,
+				});
+				console.log('데이터가 성공적으로 생성되었습니다:', docRef.id);
+			} else {
+				console.error('토큰이 존재하지 않습니다');
+			}
+		} catch (error) {
+			console.error('데이터 생성을 실패했습니다:', error);
+		}
+	};
 
-  const CreateDocument = async (data) => {
-    try {
-      if (uid !== null) {
-        const createdAt = timestamp.fromDate(new Date());
-        data.userId = uid;
-        const docRef = await addDoc(collection(appFireStore, collectionName), {...data, createdAt});
-        console.log('데이터가 성공적으로 생성되었습니다:', docRef.id);
-      } else {
-        console.error('토큰이 존재하지 않습니다');
-      }
-    } catch (error) {
-      console.error('데이터 생성을 실패했습니다:', error);
-    }
+	const CreateDocumentWithCustomID = async (documentId, data) => {
+		try {
+			const documentRef = doc(appFireStore, collectionName, documentId);
+			await setDoc(documentRef, { ...data });
 
-  }
-  return { CreateDocument };
-}
+			console.log('데이터가 성공적으로 생성되었습니다: ', documentId);
+		} catch (error) {
+			console.error('데이터 생성에 실패했습니다: ', error);
+		}
+	};
+	return { CreateDocument, CreateDocumentWithCustomID };
+};

--- a/src/hooks/useFirestoreDelete.tsx
+++ b/src/hooks/useFirestoreDelete.tsx
@@ -2,71 +2,106 @@ import { appFireStore } from '../firebase/config';
 import { doc, deleteDoc, getDoc, updateDoc } from 'firebase/firestore';
 
 export const useFirestoreDelete = (collectionName) => {
-  const token = sessionStorage.getItem('token');
-  const uid = token !== null ? JSON.parse(token).uid : null;
+	const token = sessionStorage.getItem('token');
+	const uid = token !== null ? JSON.parse(token).uid : null;
 
-  const DeleteDocument = async (documentId) => {
-    try {
-      if (uid !== null) {
-        const docRef = doc(appFireStore, collectionName, documentId);
-        const docSnapshot = await getDoc(docRef);
+	const DeleteDocument = async (documentId) => {
+		try {
+			if (uid !== null) {
+				const docRef = doc(appFireStore, collectionName, documentId);
+				const docSnapshot = await getDoc(docRef);
 
-        if (docSnapshot.exists() && docSnapshot.data().userId === uid) {
-          // 문서 삭제
-          await deleteDoc(docRef);
-          console.log('데이터가 성공적으로 삭제되었습니다');
-        } else {
-          console.error('해당 문서를 찾을 수 없거나 권한이 없습니다');
-        }
-      } else {
-        console.error('UID가 없습니다');
-      }
-    } catch (error) {
-      console.error('데이터 삭제를 실패했습니다:', error);
-    }
-  };
+				if (docSnapshot.exists() && docSnapshot.data().userId === uid) {
+					// 문서 삭제
+					await deleteDoc(docRef);
+					console.log('데이터가 성공적으로 삭제되었습니다');
+				} else {
+					console.error('해당 문서를 찾을 수 없거나 권한이 없습니다');
+				}
+			} else {
+				console.error('UID가 없습니다');
+			}
+		} catch (error) {
+			console.error('데이터 삭제를 실패했습니다:', error);
+		}
+	};
 
-  const DeleteField = async (documentId, fieldName, elementToDelete = "") => {
-    try {
-      if (uid !== null) {
-        const docRef = doc(appFireStore, collectionName, documentId);
-        const docSnapshot = await getDoc(docRef);
+	const DeleteField = async (documentId, fieldName, elementToDelete = '') => {
+		console.log(documentId, fieldName, elementToDelete);
+		try {
+			if (uid !== null) {
+				const docRef = doc(appFireStore, collectionName, documentId);
+				const docSnapshot = await getDoc(docRef);
 
-        if (docSnapshot.exists() && docSnapshot.data().userId === uid) {
-            const existingData = docSnapshot.data();
-            const arrayField = existingData[fieldName];
+				if (docSnapshot.exists() && docSnapshot.data().userId === uid) {
+					const existingData = docSnapshot.data();
+					const arrayField = existingData[fieldName];
 
-            if (Array.isArray(arrayField)) {
-              if (arrayField.includes(elementToDelete)) {
-                const newArrayField = arrayField.filter(item => item !== elementToDelete);
+					if (Array.isArray(arrayField)) {
+						if (arrayField.includes(elementToDelete)) {
+							const newArrayField = arrayField.filter(
+								(item) => item !== elementToDelete
+							);
 
-                const updateData = {};
-                updateData[fieldName] = newArrayField;
+							const updateData = {};
+							updateData[fieldName] = newArrayField;
 
-                await updateDoc(docRef, updateData);
-                console.log(`필드 '${fieldName}'의 '${elementToDelete}' 원소가 성공적으로 삭제되었습니다`);
-              } else {
-                console.error(`필드 '${fieldName}'에 '${elementToDelete}' 원소가 존재하지 않습니다.`);
-              }
-            } else {
-              const updateData = {};
-              updateData[fieldName] = null;
-    
-              await updateDoc(docRef, updateData);
-              console.log(`필드 '${fieldName}'가 성공적으로 삭제되었습니다`);
-            }
-        } else {
-          console.error('해당 문서를 찾을 수 없거나 권한이 없습니다.');
-        }
-      } else {
-        console.error('UID가 없습니다.');
-      }
-    } catch (error) {
-      console.error('원소 삭제를 실패했습니다:', error);
-    }
-  }
+							await updateDoc(docRef, updateData);
+							console.log(
+								`필드 '${fieldName}'의 '${elementToDelete}' 원소가 성공적으로 삭제되었습니다`
+							);
+						} else {
+							console.error(
+								`필드 '${fieldName}'에 '${elementToDelete}' 원소가 존재하지 않습니다.`
+							);
+						}
+					} else {
+						const updateData = {};
+						updateData[fieldName] = null;
 
-  return { DeleteDocument, DeleteField };
+						await updateDoc(docRef, updateData);
+						console.log(`필드 '${fieldName}'가 성공적으로 삭제되었습니다`);
+					}
+				} else {
+					console.error('해당 문서를 찾을 수 없거나 권한이 없습니다.');
+				}
+			} else {
+				console.error('UID가 없습니다.');
+			}
+		} catch (error) {
+			console.error('원소 삭제를 실패했습니다:', error);
+		}
+	};
+
+	const DeleteSearchHistoryEntry = async (documentId, searchHistoryIndex) => {
+		try {
+			if (uid !== null) {
+				const docRef = doc(appFireStore, collectionName, documentId);
+				const docSnapshot = await getDoc(docRef);
+				if (docSnapshot.exists() && docSnapshot.data().uid === uid) {
+					const existingData = docSnapshot.data();
+					const searchHistories = existingData.searchHistories || [];
+
+					if (searchHistories.length > searchHistoryIndex) {
+						// 지정된 검색 기록 항목 삭제
+						searchHistories.splice(searchHistoryIndex, 1);
+
+						// 수정된 searchHistories 배열로 문서 업데이트
+						await updateDoc(docRef, { searchHistories });
+						console.log('검색 기록이 성공적으로 삭제되었습니다');
+					} else {
+						console.error('검색 기록을 찾을 수 없습니다');
+					}
+				} else {
+					console.error('해당 문서를 찾을 수 없거나 권한이 없습니다.');
+				}
+			} else {
+				console.error('UID가 없습니다.');
+			}
+		} catch (error) {
+			console.error('검색 기록 삭제를 실패했습니다:', error);
+		}
+	};
+
+	return { DeleteDocument, DeleteField, DeleteSearchHistoryEntry };
 };
-
-

--- a/src/hooks/useSignUp.ts
+++ b/src/hooks/useSignUp.ts
@@ -1,60 +1,98 @@
-import { useState } from "react";
-import { appAuth } from "../firebase/config";
-import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
+import { useState } from 'react';
+import { appAuth, appFireStore } from '../firebase/config';
+import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
+import { doc, setDoc } from 'firebase/firestore';
+
+interface UserProfileDocument {
+	uid: string;
+	userId: string;
+	userName: string;
+	description: string;
+	createdFolders: string[];
+	bookmarkedFolders: string[];
+	followers: string[];
+	following: string[];
+	groups: string[];
+	posts: string[];
+	profileImageURL: string;
+	searchHistories: {
+		title: string;
+		relatedPost?: number;
+		historyCategory: 'tag' | 'user' | 'text';
+		followerCount?: number;
+	}[];
+}
 
 interface SignUpData {
-  email: string;
-  password: string;
-  userName: string;
-  accountID: string;
+	email: string;
+	password: string;
+	userName: string;
+	accountID: string;
 }
 
 interface SignUpHook {
-  error: string | null;
-  isPending: boolean;
-  signUpHook: (signUpData: SignUpData) => void;
+	error: string | null;
+	isPending: boolean;
+	signUpHook: (signUpData: SignUpData) => void;
 }
 
 export const useSignUpHook = (): SignUpHook => {
-  const [error, setError] = useState<string | null>(null);
-  const [isPending, setIsPending] = useState<boolean>(false);
+	const [error, setError] = useState<string | null>(null);
+	const [isPending, setIsPending] = useState<boolean>(false);
 
-  const signUpHook = (signUpData: SignUpData) => {
-    setError(null);
-    setIsPending(true);
-    const myEmail = signUpData.email;
-    const myPassword = signUpData.password;
-    const myName = signUpData.userName;
-    const myAccountID = signUpData.accountID;
+	const signUpHook = async (signUpData: SignUpData) => {
+		setError(null);
+		setIsPending(true);
+		const myEmail = signUpData.email;
+		const myPassword = signUpData.password;
+		const myName = signUpData.userName;
+		const myAccountID = signUpData.accountID;
 
-    createUserWithEmailAndPassword(appAuth, myEmail, myPassword)
-      .then((userCredential) => {
-        const user = userCredential.user;
-        if (!user) {
-          throw new Error("회원가입에 실패했습니다.");
-        }
+		try {
+			const userCredential = await createUserWithEmailAndPassword(
+				appAuth,
+				myEmail,
+				myPassword
+			);
+			const user = userCredential.user;
 
-        const customUserData = {
-          displayName: myAccountID,
-          userRealName: myName,
-        };
+			if (!user) {
+				throw new Error('회원가입에 실패했습니다.');
+			}
 
-        updateProfile(appAuth.currentUser, customUserData)
-          .then(() => {
-            setError(null);
-            setIsPending(false);
-            console.log("customUserData", customUserData);
-          })
-          .catch((e) => {
-            setError(e.message);
-            setIsPending(false);
-          });
-      })
-      .catch((e) => {
-        setError(e.message);
-        setIsPending(false);
-      });
-  };
+			const customUserData = {
+				displayName: myAccountID,
+				userRealName: myName,
+			};
 
-  return { error, isPending, signUpHook };
+			const customUserDocument: UserProfileDocument = {
+				uid: user.uid,
+				userId: myAccountID,
+				userName: myName,
+				description: '',
+				createdFolders: [],
+				bookmarkedFolders: [],
+				followers: [],
+				following: [],
+				groups: [],
+				posts: [],
+				profileImageURL: '',
+				searchHistories: [],
+			};
+
+			const userProfileDocRef = doc(appFireStore, 'users', user.uid);
+			await setDoc(userProfileDocRef, customUserDocument);
+
+			await updateProfile(appAuth.currentUser, customUserData);
+
+			setError(null);
+			setIsPending(false);
+			console.log('회원가입 및 사용자 데이터 추가가 완료되었습니다.');
+		} catch (e: any) {
+			setError(e.message);
+			setIsPending(false);
+		}
+	};
+
+	return { error, isPending, signUpHook };
 };

--- a/src/hooks/useSignUp.ts
+++ b/src/hooks/useSignUp.ts
@@ -12,7 +12,6 @@ interface UserProfileDocument {
 	bookmarkedFolders: string[];
 	followers: string[];
 	following: string[];
-	groups: string[];
 	posts: string[];
 	profileImageURL: string;
 	searchHistories: {
@@ -74,7 +73,6 @@ export const useSignUpHook = (): SignUpHook => {
 				bookmarkedFolders: [],
 				followers: [],
 				following: [],
-				groups: [],
 				posts: [],
 				profileImageURL: '',
 				searchHistories: [],

--- a/src/hooks/useSignUp.ts
+++ b/src/hooks/useSignUp.ts
@@ -47,6 +47,7 @@ export const useSignUpHook = (): SignUpHook => {
 		const myName = signUpData.userName;
 		const myAccountID = signUpData.accountID;
 
+		// 들여쓰기 테스트를 위한 주석 추가
 		try {
 			const userCredential = await createUserWithEmailAndPassword(
 				appAuth,

--- a/src/hooks/useSignUp.ts
+++ b/src/hooks/useSignUp.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { appAuth, appFireStore } from '../firebase/config';
+import { appAuth } from '../firebase/config';
 import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
 import { useFirestoreCreate } from './useFirestoreCreate';
 


### PR DESCRIPTION
> 이슈번호 #22 

# 전달 사항
이번 PR에서는 다음과 같은 기능을 구현했습니다.
* 사용자별 검색 기록 불러오기
* 사용자별 검색 기록 삭제 및 업데이트
* 회원가입 시 기본 사용자 정보를 Firestore에 업데이트

# 주요 변경 사항
## useFirestoreCreate.tsx
기존의 createDocument hook의 경우 addDoc을 사용하고 있기 때문에 firestore에 저장되는 document의 이름이 무작위 uid로 결정되고 있습니다.
그러나 사용자 정보나 태그 같은 경우 document의 이름을 uid와 태그 명과 같이 지정해 주기로 결정했기 때문에 이를 위한 `CreateDocumentWithCustomID`라는 유틸 함수를 따로 만들었습니다.
```typescript
const CreateDocumentWithCustomID = async (documentId, data) => {
    try {
        const documentRef = doc(appFireStore, collectionName, documentId);
	await setDoc(documentRef, { ...data });

	console.log('데이터가 성공적으로 생성되었습니다: ', documentId);
    } catch (error) {
	console.error('데이터 생성에 실패했습니다: ', error);
    }
};
```
![Screenshot 2023-12-14 at 12 10 01 PM](https://github.com/Sowith/sowith/assets/113353436/588e6552-283d-4ae9-ba58-18116359f595)

이제 위와 같이 회원가입을 하게 되면 Firestore에 사용자의 기본적인 정보가 생성됩니다.

# 추후 작업
* [ ] 검색 상세 페이지에서 각 콘텐츠와의 상호작용
* [ ] 검색 키워드 생성