### PR TITLE
🐞Fix: 카테고리 검색 페이지 라우터 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,10 @@ export function App(): JSX.Element {
 						element={<SearchTrendingFolder />}
 					/>
 					<Route path='/searchhistory' element={<SearchHistory />} />
-					<Route path='/search/:category' element={<SearchByCategory />} />
+					<Route
+						path='/search/:category/:searchKeyword'
+						element={<SearchByCategory />}
+					/>
 					<Route path='/profileUpdatePage' element={<ProfileUpdatePage />} />
 					<Route path='/com' element={<SignUpCompletedPage />} />
 					<Route path='/mainpostview' element={<MainPostViewPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
 
@@ -42,7 +41,7 @@ export function App(): JSX.Element {
 						element={<SearchTrendingFolder />}
 					/>
 					<Route path='/searchhistory' element={<SearchHistory />} />
-					<Route path='/searchbycategory' element={<SearchByCategory />} />
+					<Route path='/search/:category' element={<SearchByCategory />} />
 					<Route path='/profileUpdatePage' element={<ProfileUpdatePage />} />
 					<Route path='/com' element={<SignUpCompletedPage />} />
 					<Route path='/mainpostview' element={<MainPostViewPage />} />

--- a/src/components/common/BackButton.tsx
+++ b/src/components/common/BackButton.tsx
@@ -1,25 +1,30 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import arrowBack from '../../assets/icon/icon-arrow.svg';
 
 export const BackButton: React.FC = () => {
-  const navigate = useNavigate();
+	const navigate = useNavigate();
+	const location = useLocation();
 
-  const handleBackButtonClick = (): void => {
-    navigate(-1);
-  };
+	const handleBackButtonClick = (): void => {
+		if (location.pathname.startsWith('/search/')) {
+			navigate('/searchmain');
+		} else {
+			navigate(-1);
+		}
+	};
 
-  return <StyledBackButton onClick={handleBackButtonClick} />;
+	return <StyledBackButton onClick={handleBackButtonClick} />;
 };
 
 const StyledBackButton = styled.button`
-  background-image: url(${arrowBack});
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: contain;
-  width: 20px;
-  height: 20px;
-  cursor: pointer;
-  margin-right: 10px;
+	background-image: url(${arrowBack});
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: contain;
+	width: 20px;
+	height: 20px;
+	cursor: pointer;
+	margin-right: 10px;
 `;

--- a/src/components/search/SearchFolderList.tsx
+++ b/src/components/search/SearchFolderList.tsx
@@ -17,7 +17,6 @@ export const SearchFolderList: React.FC<SearchFolderListProps> = ({
 		[]
 	);
 	const userInfo = getUserInfo();
-	console.log(userInfo);
 
 	const { UpdateField } = useFirestoreUpdate('folders');
 

--- a/src/components/search/SearchHistoryItem.tsx
+++ b/src/components/search/SearchHistoryItem.tsx
@@ -50,7 +50,7 @@ export const HistoryItem: React.FC<HistoryItemProps> = ({
 		switch (historyCategory) {
 			case 'text':
 			case 'tag':
-				navigate('/search/post', { state: title });
+				navigate(`/search/post/${title}`, { state: title });
 				break;
 			default:
 				navigate(`/${historyCategory}/view/${uid}`);

--- a/src/components/search/SearchHistoryItem.tsx
+++ b/src/components/search/SearchHistoryItem.tsx
@@ -50,7 +50,7 @@ export const HistoryItem: React.FC<HistoryItemProps> = ({
 		switch (historyCategory) {
 			case 'text':
 			case 'tag':
-				navigate('/searchbycategory', { state: title });
+				navigate('/search/post', { state: title });
 				break;
 			default:
 				navigate(`/${historyCategory}/view/${uid}`);

--- a/src/pages/search/SearchByCategoryPage.tsx
+++ b/src/pages/search/SearchByCategoryPage.tsx
@@ -6,7 +6,7 @@ import { PostList } from '../../components/search/SearchPostList';
 import { SearchFolderList } from 'components/search/SearchFolderList';
 import { AccountList } from '../../components/search/SearchAccountList';
 import { TagList } from '../../components/search/SearchTagList';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 interface Category {
 	id: number;
@@ -15,10 +15,9 @@ interface Category {
 }
 
 export const SearchByCategory: FC = () => {
-	const location = useLocation();
+	const { searchKeyword } = useParams();
+	const safeSearchKeyword = searchKeyword || '';
 	const navigate = useNavigate();
-	const searchKeyword: string = location.state;
-	console.log(searchKeyword);
 	const [currentStep, setCurrentStep] = useState<number>(1);
 	const CATEGORIES: Category[] = [
 		{ id: 1, name: '게시글', className: 'post' },
@@ -32,21 +31,23 @@ export const SearchByCategory: FC = () => {
 		const categoryPath = CATEGORIES.find(
 			(category) => category.id === categoryId
 		)?.className;
-		navigate(`/search/${categoryPath}`, { state: searchKeyword });
+		navigate(`/search/${categoryPath}/${safeSearchKeyword}`, {
+			state: safeSearchKeyword,
+		});
 	};
 
 	const renderComponentByCategory = () => {
 		switch (currentStep) {
 			case 1:
-				return <PostList searchKeyword={searchKeyword} />;
+				return <PostList searchKeyword={safeSearchKeyword} />;
 			case 2:
-				return <SearchFolderList searchKeyword={searchKeyword} />;
+				return <SearchFolderList searchKeyword={safeSearchKeyword} />;
 			case 3:
-				return <AccountList searchKeyword={searchKeyword} />;
+				return <AccountList searchKeyword={safeSearchKeyword} />;
 			case 4:
-				return <TagList searchKeyword={searchKeyword} />;
+				return <TagList searchKeyword={safeSearchKeyword} />;
 			default:
-				return <PostList searchKeyword={searchKeyword} />;
+				return <PostList searchKeyword={safeSearchKeyword} />;
 		}
 	};
 

--- a/src/pages/search/SearchByCategoryPage.tsx
+++ b/src/pages/search/SearchByCategoryPage.tsx
@@ -6,7 +6,7 @@ import { PostList } from '../../components/search/SearchPostList';
 import { SearchFolderList } from 'components/search/SearchFolderList';
 import { AccountList } from '../../components/search/SearchAccountList';
 import { TagList } from '../../components/search/SearchTagList';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 interface Category {
 	id: number;
@@ -16,17 +16,23 @@ interface Category {
 
 export const SearchByCategory: FC = () => {
 	const location = useLocation();
+	const navigate = useNavigate();
 	const searchKeyword: string = location.state;
+	console.log(searchKeyword);
 	const [currentStep, setCurrentStep] = useState<number>(1);
 	const CATEGORIES: Category[] = [
-		{ id: 1, name: '게시글', className: 'category-post' },
-		{ id: 2, name: '폴더', className: 'category-folder' },
-		{ id: 3, name: '계정', className: 'category-account' },
-		{ id: 4, name: '태그', className: 'category-tag' },
+		{ id: 1, name: '게시글', className: 'post' },
+		{ id: 2, name: '폴더', className: 'folder' },
+		{ id: 3, name: '계정', className: 'account' },
+		{ id: 4, name: '태그', className: 'tag' },
 	];
 
-	const handleButtonClick = (step: number) => {
-		setCurrentStep(step);
+	const handleButtonClick = (categoryId: number) => {
+		setCurrentStep(categoryId);
+		const categoryPath = CATEGORIES.find(
+			(category) => category.id === categoryId
+		)?.className;
+		navigate(`/search/${categoryPath}`, { state: searchKeyword });
 	};
 
 	const renderComponentByCategory = () => {
@@ -53,7 +59,6 @@ export const SearchByCategory: FC = () => {
 					{CATEGORIES.map((category) => (
 						<button
 							key={category.id}
-							className={category.className}
 							onClick={() => handleButtonClick(category.id)}
 						>
 							{category.name}

--- a/src/pages/search/SearchHistoryPage.tsx
+++ b/src/pages/search/SearchHistoryPage.tsx
@@ -62,7 +62,11 @@ export const SearchHistory: React.FC<SearchHistoryProps> = () => {
 	};
 
 	const moveSearchByCategory = (): void => {
-		navigate('/search/post', { state: searchKeyword });
+		if (searchKeyword) {
+			navigate(`/search/post/${searchKeyword}`);
+		} else {
+			navigate('/search/post');
+		}
 	};
 
 	return (

--- a/src/pages/search/SearchHistoryPage.tsx
+++ b/src/pages/search/SearchHistoryPage.tsx
@@ -62,7 +62,7 @@ export const SearchHistory: React.FC<SearchHistoryProps> = () => {
 	};
 
 	const moveSearchByCategory = (): void => {
-		navigate('/searchbycategory', { state: searchKeyword });
+		navigate('/search/post', { state: searchKeyword });
 	};
 
 	return (


### PR DESCRIPTION
> 관련 이슈: #75 

## 전달 사항
기존의 검색 상세 페이지에서는 카테고리에 따른 검색 URL이 세분화되어있지 않았습니다.
그러나 이 경우 사용자가 어떤 검색을 진행하는지 알기 어려운 문제가 있었기에 이를 세분화 할 필요가 있었습니다.
따라서 `useParams`를 사용하고, Route의 경로를 세분화시켜 현재 검색 카테고리와 사용자의 검색 키워드를 URL에 포함시켰습니다.

## 주요 변경 사항
* 카테고리 검색 페이지 Route의 경로 수정
* BackButton 컴포넌트 로직 수정
* CategorySwitcher 로직 수정

* 변경 전 URL 예시: `/searchbycategory`
* 변경 후 URL 예시: `/search/folder/%EC%B9%B4%ED%8E%98`

## 추후 작업
- Fix가 필요한 이슈 발생 시 추가적으로 진행하겠습니다.